### PR TITLE
Centralize spring-boot plugin config

### DIFF
--- a/User/pom.xml
+++ b/User/pom.xml
@@ -29,12 +29,5 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>
-        </plugins>
-    </build>
+    <!-- Inherit spring-boot-maven-plugin configuration from parent -->
 </project>

--- a/base/longsan-web/pom.xml
+++ b/base/longsan-web/pom.xml
@@ -41,16 +41,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <!-- Inherit spring-boot-maven-plugin configuration from parent -->
 
 </project>

--- a/consumer/consumer-api/pom.xml
+++ b/consumer/consumer-api/pom.xml
@@ -25,16 +25,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <!-- Inherit spring-boot-maven-plugin configuration from parent -->
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,17 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/producer/producer-api/pom.xml
+++ b/producer/producer-api/pom.xml
@@ -31,7 +31,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <skip>true</skip>
                     <finalName>${project.name}</finalName>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Summary
- manage spring-boot-maven-plugin globally
- remove duplicate plugin blocks from modules
- keep module-specific customisation in producer-api

## Testing
- `mvn -q -DskipTests clean verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6881ea1a5c388332b61f299c51391e02